### PR TITLE
Add alias to Get-ADConfig for Get-ADHealthConfig. Fixes 59

### DIFF
--- a/Public/Get-ADConfig.ps1
+++ b/Public/Get-ADConfig.ps1
@@ -13,6 +13,7 @@ function Get-ADConfig {
 
     #>
     [cmdletBinding()]
+    [Alias('Get-ADHealthConfig')]
     Param(
         [Parameter(Position=0)]
         [ValidateScript({ Test-Path $_})]


### PR DESCRIPTION
It's a breaking change to _rename_ the function. We'll alias it to get inline with the documentation and keep from having to update all the functions for a single line.

Fixes #59 